### PR TITLE
fixing excel report templates

### DIFF
--- a/docs/IFC_SharedSemanticModel.md
+++ b/docs/IFC_SharedSemanticModel.md
@@ -14,7 +14,7 @@ The **IFC Cloud Semantic Model** is a reusable Power BI dataset pattern that loa
 
 You publish the template into your own Power BI Service workspace, point its parameters at your SharePoint locations, and let Power BI Service handle refresh on a schedule. The IFC parsing is fully automated in the cloud — you no longer need to open Power BI Desktop and click **Refresh** every time the IFC model changes.
 
-For an end-to-end usage example of the IFC multi-file loading pattern this model is built on, see [IFC Multi-File Loading & Coloring Sample (Power BI)](IFC_Multi_File_Loading.md). You can also explore the [live sample semantic model](https://app.powerbi.com/onelake/details/db7b4b0b-8ec6-4f90-925e-113e4aa1c4ee/dataset/e0ccf3e9-b859-493c-aa72-5f8531654a86/overview?experience=power-bi) on Power BI Service for reference.
+For an end-to-end usage example of the IFC multi-file loading pattern this model is built on, see [IFC Multi-File Loading & Coloring Sample (Power BI)](IFC_Multi_File_Loading.md).
 
 ## Why use a cloud semantic model?
 

--- a/docs/ifc-excel-cost-tracker.md
+++ b/docs/ifc-excel-cost-tracker.md
@@ -24,7 +24,7 @@ The goal is to give project teams a single workflow for reviewing model elements
 
 Download the ready-to-use template and point it to your own IFC file:
 
-- [Download IFC Cost Tracking workbook](../_media/IFC_CostTracking.xlsx)
+- [Download IFC Cost Tracking workbook](../_media/IFC_Cost_Tracking.xlsx)
 
 
 

--- a/docs/toc.yml
+++ b/docs/toc.yml
@@ -124,7 +124,7 @@
       href: excel-ifc-viewer-guide.md
     - name: Report Templates
       expanded: true
-      href: excel-report-templates.yml
+      href: Excel-report-templates.yml
       items:
         - name: IFC Excel Cost Tracker
           href: ifc-excel-cost-tracker.md    


### PR DESCRIPTION
report templates now will expand normally, non working link in the IFC semantic model has been delted and IFC_Cost_Tracker.xlsx is downloadable.
<img width="998" height="472" alt="image" src="https://github.com/user-attachments/assets/bb075a9a-20f2-484e-89d0-63a6514969ca" />
